### PR TITLE
Add GitHub Action to auto-assign issues to the org project

### DIFF
--- a/.github/workflows/auto-assign-to-project.yml
+++ b/.github/workflows/auto-assign-to-project.yml
@@ -1,0 +1,25 @@
+name: Project automations
+on:
+  issues:
+    types:
+      - opened
+
+# map fields with customized labels
+env:
+  todo: New Requests
+
+jobs:
+  issue_opened:
+    name: issue_opened
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+    steps:
+      - name: Move issue to ${{ env.todo }}
+        uses: leonsteinhaeuser/project-beta-automations@v1.0.3
+        with:
+          gh_token: ${{ secrets.ZARF_ORG_PROJECT_TOKEN }}
+          # user: sample-user
+          organization: defenseunicorns
+          project_id: 1
+          resource_node_id: ${{ github.event.issue.node_id }}
+          status_value: ${{ env.todo }} # Target status


### PR DESCRIPTION
Closes #29 

Identical to the one that already exists in the Zarf repo.