### PR TITLE
Add Confluence Persistence

### DIFF
--- a/kustomizations/softwarefactoryaddons/confluence/common-values.yaml
+++ b/kustomizations/softwarefactoryaddons/confluence/common-values.yaml
@@ -34,3 +34,24 @@ confluence:
         secretKeyRef:
           name: "confluence.acid-confluence.credentials.postgresql.acid.zalan.do"
           key: "password"
+  volumes:
+    localHome:
+      persistentVolumeClaim:
+        # -- If true, then a PersistentVolumeClaim will be created for each local-home volume.
+        create: true
+        # -- Specifies the name of the storage class that should be used for the local-home volume claim.
+        storageClassName: local-path
+        # -- Specifies the standard Kubernetes resource requests and/or limits for the local-home volume claims.
+        resources:
+          requests:
+            storage: 1Gi
+    sharedHome:
+      persistentVolumeClaim:
+        # -- If true, then a PersistentVolumeClaim will be created for the shared-home volume.
+        create: true
+        # -- Specifies the name of the storage class that should be used for the shared-home volume claim.
+        storageClassName: local-path
+        # -- Specifies the standard Kubernetes resource requests and/or limits for the shared-home volume claims.
+        resources:
+          requests:
+            storage: 1Gi


### PR DESCRIPTION
Implements #91 Adds a persistent volume claim to allow for pod restarts without reconfiguration. Using local-path for demo storage class. 