### PR TITLE
Stop using container on e2e pipeline step

### DIFF
--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -76,7 +76,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: parse
     if: needs.parse.outputs.run-e2e == 'true'
-    container: ghcr.io/defenseunicorns/zarf-package-software-factory/build-harness:0.0.7
     steps:
       # Update GitHub status for pending pipeline run
       - name: "Update GitHub Status for pending"


### PR DESCRIPTION
The makefile runs `docker run` now for better compatibility and easier local runs. Because of that, we don't need to run the test step inside a container anymore, since `ubuntu-latest` has Docker installed and will run `docker run` just fine.