### PR TITLE
Update Confluence image to 7.17.4

### DIFF
--- a/kustomizations/softwarefactoryaddons/confluence/common-values.yaml
+++ b/kustomizations/softwarefactoryaddons/confluence/common-values.yaml
@@ -1,6 +1,6 @@
 image:
   # v0.1.0-bb.9 of this chart has a bug that doesn't use the "tag" parameter. Upgrading the version of confluence should fix
-  repository: "${ZARF_REGISTRY}/ironbank/atlassian/confluence-data-center/confluence-node:7.13.0"
+  repository: "${ZARF_REGISTRY}/ironbank/atlassian/confluence-data-center/confluence-node:7.17.4"
 imagePullSecrets:
   - name: private-registry
 ingress:

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -100,6 +100,9 @@ func SetupTestPlatform(t *testing.T, platform *types.TestPlatform) {
 		// Deploy software factory
 		output, err = platform.RunSSHCommandAsSudo("cd ~/app/build && ./zarf package deploy zarf-package-software-factory-amd64.tar.zst --confirm")
 		require.NoError(t, err, output)
+		// We have to patch the zarf-package-software-factory GitRepo to point at the right branch
+		output, err = platform.RunSSHCommandAsSudo(fmt.Sprintf(`kubectl patch gitrepositories.source.toolkit.fluxcd.io -n flux-system zarf-package-software-factory --type=json -p '[{"op": "replace", "path": "/spec/ref/branch", "value": "%v"}]'`, gitBranch))
+		require.NoError(t, err, output)
 	})
 }
 

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -173,7 +173,7 @@ components:
       - https://github.com/jenkinsci/helm-charts.git@jenkins-3.9.4
     images:
       - registry1.dso.mil/ironbank/atlassian/jira-data-center/jira-node:8.18.1
-      - registry1.dso.mil/ironbank/atlassian/confluence-data-center/confluence-node:7.13.0
+      - registry1.dso.mil/ironbank/atlassian/confluence-data-center/confluence-node:7.17.4
       - registry1.dso.mil/ironbank/opensource/jenkins/jenkins:2.320
       - jenkins/inbound-agent:4.11-1
       - kiwigrid/k8s-sidecar:1.14.2


### PR DESCRIPTION
Dirty hack to mitigate a CVE before we upgrade fully to the latest version of the confluence helm chart.