### PR TITLE
Initial documentation structure for Backup and Restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ All versions of this package will not be compatible with all versions of Zarf. H
 
 Note that having Zarf installed is not a prerequisite. This repo pulls in its own version of Zarf so that it can be versioned separately from whatever your system has installed. To change the version of Zarf used modify the ZARF_VERSION variable in the Makefile
 
-## Instructions
+## Documentation
 
 1. [Fork the repo, customize, and build the packages](doc/fork-and-build.md)
 1. [Deploy](doc/deploy.md)
+1. [Configure SOPS encryption](doc/sops.md)
 1. [Configure Single Sign-On](doc/sso.md)
 1. [Day-2 Ops/Maintenance/Upgrades](doc/day2.md)
+1. [Backup and Restore](doc/backup-and-restore/README.md)
 1. [Troubleshooting](doc/troubleshooting.md)

--- a/doc/backup-and-restore/README.md
+++ b/doc/backup-and-restore/README.md
@@ -1,0 +1,6 @@
+# Backup and Restore
+
+Depending on how you have configured your cluster, backup and restore will be very different.
+
+* [Click here if you are using a self-sufficient cluster](self-sufficient.md). This is the default functionality that uses MinIO for S3-compatible bucket storage and Postgres Operator for databases.
+* [Click here if you are using external services such as AWS S3 and AWS RDS](external-services.md)

--- a/doc/backup-and-restore/external-services.md
+++ b/doc/backup-and-restore/external-services.md
@@ -1,0 +1,45 @@
+# Backup and Restore of a cluster that uses external services
+
+:construction: **This document is under construction**. Stay tuned for more details.
+
+Use this document to perform backup and restore of a cluster that uses external services for object storage and databases, such as Amazon's S3 and RDS.
+
+## GitLab
+
+### Backing Up GitLab
+
+TODO: Write this section
+
+### Restoring GitLab
+
+TODO: Write this section
+
+## Jenkins
+
+## Backing Up Jenkins
+
+TODO: Write this section
+
+### Restoring Jenkins
+
+TODO: Write this section
+
+## Jira
+
+### Backing Up Jira
+
+TODO: Write this section
+
+### Restoring Jira
+
+TODO: Write this section
+
+## Confluence
+
+### Backing Up Confluence
+
+TODO: Write this section
+
+### Restoring Confluence
+
+TODO: Write this section

--- a/doc/backup-and-restore/external-services.md
+++ b/doc/backup-and-restore/external-services.md
@@ -2,7 +2,7 @@
 
 :construction: **This document is under construction**. Stay tuned for more details.
 
-Use this document to perform backup and restore of a cluster that uses external services for object storage and databases, such as Amazon's S3 and RDS.
+Use this document to perform backup and restore of a cluster that uses external services for object storage and databases, such as Amazon's S3 and RDS. Since external services are being used it's not as easy as just backing up the whole cluster with Velero. Instead you'll need to configure and perform backup/restore on a service-by-service basis.
 
 ## GitLab
 

--- a/doc/backup-and-restore/external-services.md
+++ b/doc/backup-and-restore/external-services.md
@@ -16,7 +16,7 @@ TODO: Write this section
 
 ## Jenkins
 
-## Backing Up Jenkins
+### Backing Up Jenkins
 
 TODO: Write this section
 

--- a/doc/backup-and-restore/self-sufficient.md
+++ b/doc/backup-and-restore/self-sufficient.md
@@ -1,0 +1,7 @@
+# Backup and Restore of a "Self Sufficient" Cluster
+
+:construction: **This document is under construction**. Please check back later.
+
+Use this document to perform backup and restore of a cluster that is self sufficient, meaning that it uses MinIO for S3-compatible object storage and Postgres Operator for databases. This is the default functionality.
+
+TODO: Write this doc. Plan right now is to use Velero to backup the whole cluster, with a note that the user will be responsible for shipping the Velero backups out of Minio to somewhere external to the cluster.


### PR DESCRIPTION
Stub out the initial structure of documentation for backup and restore, so that each section can be worked on iteratively.

Closes #70 -- Will create issues for documenting backup and restore for each service in the "external services" case and for the "one-and-done" method for the self sufficient case.