### PR TITLE
Remove Nexus from the stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Deploys the components of a software factory with the following services, all ru
 - GitLab*
 - GitLab Runner*
 - Minio Operator*
-- Nexus*
 - Jira
 - Confluence
 - Jenkins

--- a/kustomizations/bigbang/common/values.yaml
+++ b/kustomizations/bigbang/common/values.yaml
@@ -53,7 +53,6 @@ istio:
         - jenkins.{{ .Values.domain }}
         - jira.{{ .Values.domain }}
         - confluence.{{ .Values.domain }}
-        - nexus.{{ .Values.domain }}
         - registry.{{ .Values.domain }}
 
 istiooperator:
@@ -813,25 +812,3 @@ addons:
         requests:
           memory: 256Mi
           cpu: 200m
-  nexus:
-    enabled: true
-    git:
-      repo: http://zarf-gitea-http.zarf.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__developer-tools__nexus.git
-    values:
-      istio:
-        enabled: true
-        nexus:
-          gateways:
-            - istio-system/public
-      job_image:
-        repository: "${ZARF_REGISTRY}/ironbank/redhat/ubi/ubi8-minimal"
-      image:
-        repository: "${ZARF_REGISTRY}/ironbank/sonatype/nexus/nexus"
-      nexus:
-        resources:
-          requests:
-            cpu: 4
-            memory: 8000Mi
-          limits:
-            cpu: 4
-            memory: 8000Mi

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -52,7 +52,6 @@ components:
       - https://repo1.dso.mil/platform-one/big-bang/apps/application-utilities/minio.git@4.4.3-bb.3
       - https://repo1.dso.mil/platform-one/big-bang/apps/developer-tools/gitlab.git@5.6.2-bb.5
       - https://repo1.dso.mil/platform-one/big-bang/apps/developer-tools/gitlab-runner.git@0.36.0-bb.2
-      - https://repo1.dso.mil/platform-one/big-bang/apps/developer-tools/nexus.git@37.3.0-bb.1
 
     images:
       # istio-controlplane
@@ -150,10 +149,6 @@ components:
 
       # gitlab-runner
       - registry1.dso.mil/ironbank/gitlab/gitlab-runner/gitlab-runner:v14.6.0
-
-      # nexus
-      - registry1.dso.mil/ironbank/redhat/ubi/ubi8-minimal:8.5
-      - registry1.dso.mil/ironbank/sonatype/nexus/nexus:3.37.3-02
 
   - name: softwarefactoryaddons-deps
     required: true


### PR DESCRIPTION
Since Nexus isn't compatible with OIDC for SSO and we are now exploring using Artifactory, removing Nexus simplifies the stack and frees up CPU and Memory