### PR TITLE
Add testing for ensuring that the services are available from outside of the cluster

### DIFF
--- a/test/e2e/e2e_basic_smoke_test.go
+++ b/test/e2e/e2e_basic_smoke_test.go
@@ -71,5 +71,17 @@ func TestAllServicesRunning(t *testing.T) {
 		// Make sure flux is present.
 		output, err = platform.RunSSHCommandAsSudo("flux --help")
 		require.NoError(t, err, output)
+		// Ensure that Jenkins is available outside of the cluster.
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jenkins.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		require.NoError(t, err, output)
+		// Ensure that Confluence is available outside of the cluster.
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://confluence.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		require.NoError(t, err, output)
+		// Ensure that Jira is available outside of the cluster.
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jira.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		require.NoError(t, err, output)
+		// Ensure that GitLab is available outside of the cluster.
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://gitlab.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		require.NoError(t, err, output)
 	})
 }

--- a/test/e2e/e2e_basic_smoke_test.go
+++ b/test/e2e/e2e_basic_smoke_test.go
@@ -72,16 +72,16 @@ func TestAllServicesRunning(t *testing.T) {
 		output, err = platform.RunSSHCommandAsSudo("flux --help")
 		require.NoError(t, err, output)
 		// Ensure that Jenkins is available outside of the cluster.
-		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jenkins.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jenkins.bigbang.dev/login > /dev/null; do sleep 5; done\"`)
 		require.NoError(t, err, output)
 		// Ensure that Confluence is available outside of the cluster.
-		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://confluence.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://confluence.bigbang.dev/status > /dev/null; do sleep 5; done\"`)
 		require.NoError(t, err, output)
 		// Ensure that Jira is available outside of the cluster.
-		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jira.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jira.bigbang.dev/status > /dev/null; do sleep 5; done\"`)
 		require.NoError(t, err, output)
 		// Ensure that GitLab is available outside of the cluster.
-		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://gitlab.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://gitlab.bigbang.dev/-/health > /dev/null; do sleep 5; done\"`)
 		require.NoError(t, err, output)
 	})
 }


### PR DESCRIPTION
I'm expecting these new tests to fail due to [this issue](https://github.com/defenseunicorns/zarf/issues/557). Working on a fix to rollback to K3s v1.21.6+k3s1 to fix this while we figure it out over on the Zarf side.