### PR TITLE
Rollback K3s version to v1.21.6+k3s1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ clean: ## Clean up build files
 	@rm -rf ./build
 
 .PHONY: all
-all: | build/zarf build/zarf-mac-intel build/zarf-init-amd64.tar.zst build/zarf-package-flux-amd64.tar.zst build/zarf-package-software-factory-amd64.tar.zst ## Make everything. Will skip downloading/generating dependencies if they already exist.
+all: | build/zarf build/zarf-mac-intel build/zarf-init-amd64.tar.zst build/zarf-package-k3s-amd64.tar.zst build/zarf-package-k3s-images-amd64.tar.zst build/zarf-package-flux-amd64.tar.zst build/zarf-package-software-factory-amd64.tar.zst ## Make everything. Will skip downloading/generating dependencies if they already exist.
 
 .PHONY: vendor-big-bang-base
 vendor-big-bang-base: ## Vendor the BigBang base kustomization, since Flux doesn't support private bases. This only needs to be run if you change the version of Big Bang used. Don't forget to commit the changes to the repo.
@@ -128,6 +128,14 @@ build/zarf-mac-intel: | build ## Download the Mac (Intel) flavor of Zarf to the 
 build/zarf-init-amd64.tar.zst: | build ## Download the init package
 	@echo "Downloading zarf-init-amd64.tar.zst"
 	@wget -q https://github.com/defenseunicorns/zarf/releases/download/$(ZARF_VERSION)/zarf-init-amd64.tar.zst -O build/zarf-init-amd64.tar.zst
+
+build/zarf-package-k3s-amd64.tar.zst: | build ## Make the K3s package
+	@cd k3s && ../build/$(ZARF_BIN) package create --skip-sbom --confirm
+	@mv k3s/zarf-package-k3s-amd64.tar.zst build/zarf-package-k3s-amd64.tar.zst
+
+build/zarf-package-k3s-images-amd64.tar.zst: | build ## Make the k3s-images package
+	@cd k3s-images && ../build/$(ZARF_BIN) package create --skip-sbom --confirm
+	@mv k3s-images/zarf-package-k3s-images-amd64.tar.zst build/zarf-package-k3s-images-amd64.tar.zst
 
 build/zarf-package-flux-amd64.tar.zst: | build/$(ZARF_BIN) ## Build the Flux package
 	@cd flux && ../build/$(ZARF_BIN) package create --skip-sbom --confirm

--- a/k3s-images/zarf.yaml
+++ b/k3s-images/zarf.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/zarf/v0.19.5/zarf.schema.json
+kind: ZarfPackageConfig
+metadata:
+  name: k3s-images
+  description: "K3s images to load into the internal registry"
+  architecture: amd64
+
+components:
+  - name: k3s-images
+    required: true
+    description: "Load the k3s images into the internal registry"
+    images:
+      - "docker.io/rancher/coredns-coredns:1.8.3"
+      - "docker.io/rancher/klipper-helm:v0.6.6-build20211022"
+      - "docker.io/rancher/klipper-lb:v0.2.0"
+      - "docker.io/rancher/library-busybox:1.32.1"
+      - "docker.io/rancher/library-traefik:2.4.8"
+      - "docker.io/rancher/local-path-provisioner:v0.0.19"
+      - "docker.io/rancher/metrics-server:v0.3.6"
+      - "docker.io/rancher/pause:3.1"

--- a/k3s/assets/k3s.service
+++ b/k3s/assets/k3s.service
@@ -1,0 +1,27 @@
+Description=Zarf K3s Runner
+Documentation=https://repo1.dso.mil/platform-one/big-bang/apps/product-tools/zarf
+Wants=network-online.target
+After=network-online.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/default/%N
+EnvironmentFile=-/etc/sysconfig/%N
+KillMode=process
+Delegate=yes
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+TimeoutStartSec=0
+Restart=always
+RestartSec=5s
+ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service'
+ExecStartPre=-/sbin/modprobe br_netfilter
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/sbin/k3s server --write-kubeconfig-mode=700 --disable traefik

--- a/k3s/assets/zarf-clean-k3s.sh
+++ b/k3s/assets/zarf-clean-k3s.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+
+echo -e '\033[0;31m'
+
+for bin in /var/lib/rancher/k3s/data/**/bin/; do
+	[ -d $bin ] && export PATH=$PATH:$bin:$bin/aux
+done
+
+set -x
+
+for service in /etc/systemd/system/k3s*.service; do
+	[ -s $service ] && systemctl stop $(basename $service)
+done
+
+for service in /etc/init.d/k3s*; do
+	[ -x $service ] && $service stop
+done
+
+pschildren() {
+	ps -e -o ppid= -o pid= | \
+	sed -e 's/^\s*//g; s/\s\s*/\t/g;' | \
+	grep -w "^$1" | \
+	cut -f2
+}
+
+pstree() {
+	for pid in $@; do
+		echo $pid
+		for child in $(pschildren $pid); do
+			pstree $child
+		done
+	done
+}
+
+killtree() {
+	kill -9 $(
+		{ set +x; } 2>/dev/null;
+		pstree $@;
+		set -x;
+	) 2>/dev/null
+}
+
+getshims() {
+	ps -e -o pid= -o args= | sed -e 's/^ *//; s/\s\s*/\t/;' | grep -w 'k3s/data/[^/]*/bin/containerd-shim' | cut -f1
+}
+
+killtree $({ set +x; } 2>/dev/null; getshims; set -x)
+
+do_unmount_and_remove() {
+	awk -v path="$1" '$2 ~ ("^" path) { print $2 }' /proc/self/mounts | sort -r | xargs -r -t -n 1 sh -c 'umount "$0" && rm -rf "$0"'
+}
+
+do_unmount_and_remove '/run/k3s'
+do_unmount_and_remove '/var/lib/rancher/k3s'
+do_unmount_and_remove '/var/lib/kubelet/pods'
+do_unmount_and_remove '/var/lib/kubelet/plugins'
+do_unmount_and_remove '/run/netns/cni-'
+
+# Remove CNI namespaces
+ip netns show 2>/dev/null | grep cni- | xargs -r -t -n 1 ip netns delete
+
+# Delete network interface(s) that match 'master cni0'
+ip link show 2>/dev/null | grep 'master cni0' | while read ignore iface ignore; do
+	iface=${iface%%@*}
+	[ -z "$iface" ] || ip link delete $iface
+done
+ip link delete cni0
+ip link delete flannel.1
+rm -rf /var/lib/cni/
+iptables-save | grep -v KUBE- | grep -v CNI- | iptables-restore
+
+if command -v systemctl; then
+	systemctl disable k3s
+	systemctl reset-failed k3s
+	systemctl daemon-reload
+fi
+
+rm -f /etc/systemd/system/k3s.service
+
+for cmd in kubectl crictl ctr; do
+	if [ -L /usr/sbin/$cmd ]; then
+		rm -f /usr/sbin/$cmd
+	fi
+done
+
+rm -rf /etc/rancher/k3s
+rm -rf /run/k3s
+rm -rf /run/flannel
+rm -rf /var/lib/rancher/k3s
+rm -rf /var/lib/kubelet
+rm -f /usr/sbin/k3s
+rm -f /usr/sbin/ctr
+rm -f /usr/sbin/crictl
+rm -f /usr/sbin/kubectl
+rm -f /opt/zarf/k3s-remove.sh
+rm -fr zarf-pki
+
+echo -e '\033[0m'

--- a/k3s/zarf.yaml
+++ b/k3s/zarf.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/zarf/v0.19.5/zarf.schema.json
+kind: ZarfPackageConfig
+metadata:
+  name: "k3s"
+  description: "Used to establish a new Zarf cluster"
+  architecture: amd64
+
+components:
+  - name: k3s
+    required: true
+    description: >
+      *** REQUIRES ROOT ***
+      Install K3s, certified Kubernetes distribution built for IoT & Edge computing.
+      K3s provides the cluster need for Zarf running in Appliance Mode as well as can
+      host a low-resource Gitops Service if not using an existing Kubernetes platform.
+    scripts:
+      retry: true
+      before:
+        # If running RHEL variant, disable firewalld
+        # https://rancher.com/docs/k3s/latest/en/advanced/#additional-preparation-for-red-hat-centos-enterprise-linux
+        # NOTE: The empty echo prevents infinite retry loops on non-RHEL systems where the exit code would be an error
+        - "[ -e /etc/redhat-release ] && systemctl disable firewalld --now || echo ''"
+      after:
+        # Configure K3s systemd service
+        - "systemctl daemon-reload"
+        - "systemctl enable --now k3s"
+    files:
+      # Include the actual K3s binary
+      - source: https://github.com/k3s-io/k3s/releases/download/v1.21.6+k3s1/k3s
+        shasum: 89eb5f3d12524d0a9d5b56ba3e2707b106e1731dd0e6d2e7b898ac585f4959df
+        target: /usr/sbin/k3s
+        executable: true
+        # K3s magic provides these tools when symlinking
+        symlinks:
+          - /usr/sbin/kubectl
+          - /usr/sbin/ctr
+          - /usr/sbin/crictl
+      # Transfer the K3s images for containerd to pick them up
+      - source: https://github.com/k3s-io/k3s/releases/download/v1.21.6+k3s1/k3s-airgap-images-amd64.tar.zst
+        shasum: 772ae839f8c7718e2022d103076df53452d4f09d2a22afdf4b5796cf0cbce62c
+        target: /var/lib/rancher/k3s/agent/images/k3s.tar.zst
+      # K3s removal script
+      - source: assets/zarf-clean-k3s.sh
+        target: /opt/zarf/zarf-clean-k3s.sh
+        executable: true
+      # The K3s systemd service definition
+      - source: assets/k3s.service
+        target: /etc/systemd/system/k3s.service
+        symlinks:
+          - /etc/systemd/system/multi-user.target.wants/k3s.service
+      # Mock file for creating the kube config symlink
+      - source: assets/empty-file
+        target: /etc/rancher/k3s/k3s.yaml
+        symlinks:
+          - /root/.kube/config
+
+  # - name: k3s-images
+  #   required: true
+  #   description: "Load the k3s images into the internal registry"
+  #   images:
+  #     - "docker.io/rancher/coredns-coredns:1.8.3"
+  #     - "docker.io/rancher/klipper-helm:v0.6.6-build20211022"
+  #     - "docker.io/rancher/klipper-lb:v0.2.0"
+  #     - "docker.io/rancher/library-busybox:1.32.1"
+  #     - "docker.io/rancher/library-traefik:2.4.8"
+  #     - "docker.io/rancher/local-path-provisioner:v0.0.19"
+  #     - "docker.io/rancher/metrics-server:v0.3.6"
+  #     - "docker.io/rancher/pause:3.1"

--- a/k3s/zarf.yaml
+++ b/k3s/zarf.yaml
@@ -53,16 +53,3 @@ components:
         target: /etc/rancher/k3s/k3s.yaml
         symlinks:
           - /root/.kube/config
-
-  # - name: k3s-images
-  #   required: true
-  #   description: "Load the k3s images into the internal registry"
-  #   images:
-  #     - "docker.io/rancher/coredns-coredns:1.8.3"
-  #     - "docker.io/rancher/klipper-helm:v0.6.6-build20211022"
-  #     - "docker.io/rancher/klipper-lb:v0.2.0"
-  #     - "docker.io/rancher/library-busybox:1.32.1"
-  #     - "docker.io/rancher/library-traefik:2.4.8"
-  #     - "docker.io/rancher/local-path-provisioner:v0.0.19"
-  #     - "docker.io/rancher/metrics-server:v0.3.6"
-  #     - "docker.io/rancher/pause:3.1"

--- a/test/e2e/e2e_basic_smoke_test.go
+++ b/test/e2e/e2e_basic_smoke_test.go
@@ -71,5 +71,17 @@ func TestAllServicesRunning(t *testing.T) {
 		// Make sure flux is present.
 		output, err = platform.RunSSHCommandAsSudo("flux --help")
 		require.NoError(t, err, output)
+		// Ensure that Jenkins is available outside of the cluster.
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jenkins.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		require.NoError(t, err, output)
+		// Ensure that Confluence is available outside of the cluster.
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://confluence.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		require.NoError(t, err, output)
+		// Ensure that Jira is available outside of the cluster.
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jira.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		require.NoError(t, err, output)
+		// Ensure that GitLab is available outside of the cluster.
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://gitlab.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		require.NoError(t, err, output)
 	})
 }

--- a/test/e2e/e2e_basic_smoke_test.go
+++ b/test/e2e/e2e_basic_smoke_test.go
@@ -72,16 +72,16 @@ func TestAllServicesRunning(t *testing.T) {
 		output, err = platform.RunSSHCommandAsSudo("flux --help")
 		require.NoError(t, err, output)
 		// Ensure that Jenkins is available outside of the cluster.
-		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jenkins.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jenkins.bigbang.dev/login > /dev/null; do sleep 5; done\"`)
 		require.NoError(t, err, output)
 		// Ensure that Confluence is available outside of the cluster.
-		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://confluence.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://confluence.bigbang.dev/status > /dev/null; do sleep 5; done\"`)
 		require.NoError(t, err, output)
 		// Ensure that Jira is available outside of the cluster.
-		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jira.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://jira.bigbang.dev/status > /dev/null; do sleep 5; done\"`)
 		require.NoError(t, err, output)
 		// Ensure that GitLab is available outside of the cluster.
-		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://gitlab.bigbang.dev > /dev/null; do sleep 5; done\"`)
+		output, err = platform.RunSSHCommandAsSudo(`timeout 1200 bash -c \"while ! curl -L -s --fail --show-error https://gitlab.bigbang.dev/-/health > /dev/null; do sleep 5; done\"`)
 		require.NoError(t, err, output)
 	})
 }

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -74,17 +74,31 @@ func SetupTestPlatform(t *testing.T, platform *types.TestPlatform) {
 		// Log into registry1.dso.mil
 		output, err = platform.RunSSHCommandAsSudo(fmt.Sprintf("~/app/build/zarf tools registry login registry1.dso.mil -u %v -p %v", registry1Username, registry1Password))
 		require.NoError(t, err, output)
-		// Build the rest of the packages
+		// Build K3s package
+		output, err = platform.RunSSHCommandAsSudo("cd ~/app && make build/zarf-package-k3s-amd64.tar.zst")
+		require.NoError(t, err, output)
+		// Build k3s-images package
+		output, err = platform.RunSSHCommandAsSudo("cd ~/app && make build/zarf-package-k3s-images-amd64.tar.zst")
+		require.NoError(t, err, output)
+		// Build init package
 		output, err = platform.RunSSHCommandAsSudo("cd ~/app && make build/zarf-init-amd64.tar.zst")
 		require.NoError(t, err, output)
+		// Build flux package
 		output, err = platform.RunSSHCommandAsSudo("cd ~/app && make build/zarf-package-flux-amd64.tar.zst")
 		require.NoError(t, err, output)
+		// Build software factory package
 		output, err = platform.RunSSHCommandAsSudo("cd ~/app && make build/zarf-package-software-factory-amd64.tar.zst")
 		require.NoError(t, err, output)
 		// Try to be idempotent
 		_, _ = platform.RunSSHCommandAsSudo("cd ~/app/build && ./zarf destroy --confirm")
-		// Init package
-		output, err = platform.RunSSHCommandAsSudo("cd ~/app/build && ./zarf package deploy zarf-init-amd64.tar.zst --components k3s,git-server --confirm")
+		// Deploy K3s
+		output, err = platform.RunSSHCommandAsSudo("cd ~/app/build && ./zarf package deploy zarf-package-k3s-amd64.tar.zst --confirm")
+		require.NoError(t, err, output)
+		// Deploy init package
+		output, err = platform.RunSSHCommandAsSudo("cd ~/app/build && ./zarf package deploy zarf-init-amd64.tar.zst --components git-server --confirm")
+		require.NoError(t, err, output)
+		// Deploy k3s-images
+		output, err = platform.RunSSHCommandAsSudo("cd ~/app/build && ./zarf package deploy zarf-package-k3s-images-amd64.tar.zst --confirm")
 		require.NoError(t, err, output)
 		// Deploy Flux
 		output, err = platform.RunSSHCommandAsSudo("cd ~/app/build && ./zarf package deploy zarf-package-flux-amd64.tar.zst --confirm")


### PR DESCRIPTION
Rollback K3s version to v1.21.6+k3s1 due to [this issue](https://github.com/defenseunicorns/zarf/issues/557) by making our own k3s package, as well as a `k3s-images` package so that the images that k3s uses are in the zarf registry.

Contains the same tests as #223 which I expect to pass now that the older version of K3s is being used.