### PR TITLE
Replaced wget commands with curl in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,17 +117,17 @@ build:
 
 build/zarf: | build ## Download the Linux flavor of Zarf to the build dir
 	@echo "Downloading zarf"
-	@wget -q https://github.com/defenseunicorns/zarf/releases/download/$(ZARF_VERSION)/zarf_$(ZARF_VERSION)_Linux_amd64 -O build/zarf
+	@curl -sL https://github.com/defenseunicorns/zarf/releases/download/$(ZARF_VERSION)/zarf_$(ZARF_VERSION)_Linux_amd64 -o build/zarf
 	@chmod +x build/zarf
 
 build/zarf-mac-intel: | build ## Download the Mac (Intel) flavor of Zarf to the build dir
 	@echo "Downloading zarf-mac-intel"
-	@wget -q https://github.com/defenseunicorns/zarf/releases/download/$(ZARF_VERSION)/zarf_$(ZARF_VERSION)_Darwin_amd64 -O build/zarf-mac-intel
+	@curl -sL https://github.com/defenseunicorns/zarf/releases/download/$(ZARF_VERSION)/zarf_$(ZARF_VERSION)_Darwin_amd64 -o build/zarf-mac-intel
 	@chmod +x build/zarf-mac-intel
 
 build/zarf-init-amd64.tar.zst: | build ## Download the init package
 	@echo "Downloading zarf-init-amd64.tar.zst"
-	@wget -q https://github.com/defenseunicorns/zarf/releases/download/$(ZARF_VERSION)/zarf-init-amd64.tar.zst -O build/zarf-init-amd64.tar.zst
+	@curl -sL https://github.com/defenseunicorns/zarf/releases/download/$(ZARF_VERSION)/zarf-init-amd64.tar.zst -o build/zarf-init-amd64.tar.zst
 
 build/zarf-package-k3s-amd64.tar.zst: | build ## Make the K3s package
 	@cd k3s && ../build/$(ZARF_BIN) package create --skip-sbom --confirm


### PR DESCRIPTION
The Makefile for DI2-ME is responsible for downloading required zarf binaries with `wget`. `wget` is not as widely available as `curl` so the three uses of `wget` were replaced with `curl` following the pattern below:

```
wget -q [url] -O [file]
# replaced with
curl -sL [url] -o [file]
```

Local tests proved the `curl` statements result in the same outcome as the original `wgef`s.