### PR TITLE
Add dependency on the $(ZARF_BIN) when building zarf packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,11 +129,11 @@ build/zarf-init-amd64.tar.zst: | build ## Download the init package
 	@echo "Downloading zarf-init-amd64.tar.zst"
 	@curl -sL https://github.com/defenseunicorns/zarf/releases/download/$(ZARF_VERSION)/zarf-init-amd64.tar.zst -o build/zarf-init-amd64.tar.zst
 
-build/zarf-package-k3s-amd64.tar.zst: | build ## Make the K3s package
+build/zarf-package-k3s-amd64.tar.zst: | build/$(ZARF_BIN) ## Make the K3s package
 	@cd k3s && ../build/$(ZARF_BIN) package create --skip-sbom --confirm
 	@mv k3s/zarf-package-k3s-amd64.tar.zst build/zarf-package-k3s-amd64.tar.zst
 
-build/zarf-package-k3s-images-amd64.tar.zst: | build ## Make the k3s-images package
+build/zarf-package-k3s-images-amd64.tar.zst: | build/$(ZARF_BIN) ## Make the k3s-images package
 	@cd k3s-images && ../build/$(ZARF_BIN) package create --skip-sbom --confirm
 	@mv k3s-images/zarf-package-k3s-images-amd64.tar.zst build/zarf-package-k3s-images-amd64.tar.zst
 


### PR DESCRIPTION
When running `make all` after `make clean`, the required `$(ZARF_BIN)` was not yet in place when running the `build/zarf-package-k3s-images-amd64.tar.zst` and `build/zarf-package-k3s-amd64.tar.zst` targets.

The dependency has been updated to require the correct `$(ZARF_BIN)`