### PR TITLE
Dependency version updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,12 @@
 run:
   timeout: 5m
-  skip-files:
-    - src/internal/message/logo.go
 linters:
   enable-all: true
   disable:
     - exhaustivestruct
     - exhaustruct
     - goerr113
-    #   - gofumpt
+    - gofumpt
     - lll
     - stylecheck
     #   - testpackage
@@ -19,4 +17,6 @@ linters-settings:
   funlen:
     lines: 120
 issues:
+  exclude:
+    - "G304" # Potential file inclusion via variable
   exclude-use-default: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,6 @@ repos:
       - id: go-fmt
       - id: golangci-lint
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 32.111.0
+    rev: 32.154.7
     hooks:
       - id: renovate-config-validator

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: fix-smartquotes
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.17.0
+    rev: 0.17.1
     hooks:
       - id: check-jsonschema
         name: "Validate Zarf Configs Against Schema"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.18.3
+golang 1.19
 golangci-lint 1.46.2
 python 3.10.5
 hadolint 2.10.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,7 @@ python 3.10.6
 hadolint 2.10.0
 pre-commit 2.19.0
 terraform 1.2.4
-tflint 0.38.1
+tflint 0.39.2
 tfsec 1.26.0
 sops 3.7.3
 make 4.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golang 1.19
-golangci-lint 1.46.2
+golangci-lint 1.48.0
 python 3.10.6
 hadolint 2.10.0
 pre-commit 2.19.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,7 +3,7 @@ golangci-lint 1.48.0
 python 3.10.6
 hadolint 2.10.0
 pre-commit 2.19.0
-terraform 1.2.4
+terraform 1.2.7
 tflint 0.39.2
 tfsec 1.27.1
 sops 3.7.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,6 +5,6 @@ hadolint 2.10.0
 pre-commit 2.19.0
 terraform 1.2.4
 tflint 0.39.2
-tfsec 1.26.0
+tfsec 1.27.1
 sops 3.7.3
 make 4.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 golang 1.19
 golangci-lint 1.46.2
-python 3.10.5
+python 3.10.6
 hadolint 2.10.0
 pre-commit 2.19.0
 terraform 1.2.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ RUN asdf plugin add tflint \
   && asdf install tflint "${TFLINT_VERSION}"
 
 # Install tfsec. Get versions using 'asdf list all tfsec'
-ARG TFSEC_VERSION="1.26.0"
+ARG TFSEC_VERSION="1.27.1"
 ENV TFSEC_VERSION=${TFSEC_VERSION}
 RUN asdf plugin add tfsec \
   && asdf install tfsec "${TFSEC_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN asdf plugin add pre-commit \
   && asdf install pre-commit "${PRE_COMMIT_VERSION}"
 
 # Install Terraform. Get versions using 'asdf list all terraform'
-ARG TERRAFORM_VERSION="1.2.4"
+ARG TERRAFORM_VERSION="1.2.7"
 ENV TERRAFORM_VERSION=${TERRAFORM_VERSION}
 RUN asdf plugin add terraform \
   && asdf install terraform "${TERRAFORM_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN asdf plugin add golang \
   && asdf install golang "${GOLANG_VERSION}"
 
 # Install golangci-lint. Get versions using 'asdf list all golangci-lint'
-ARG GOLANGCILINT_VERSION="1.46.2"
+ARG GOLANGCILINT_VERSION="1.48.0"
 ENV GOLANGCILINT_VERSION=${GOLANGCILINT_VERSION}
 RUN asdf plugin add golangci-lint \
   && asdf install golangci-lint "${GOLANGCILINT_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN asdf plugin add golangci-lint \
   && asdf install golangci-lint "${GOLANGCILINT_VERSION}"
 
 # Install python. Get versions using 'asdf list all python'
-ARG PYTHON_VERSION="3.10.5"
+ARG PYTHON_VERSION="3.10.6"
 ENV PYTHON_VERSION=${PYTHON_VERSION}
 RUN asdf plugin add python \
   && asdf install python "${PYTHON_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ENV PATH="/root/.asdf/shims:/root/.asdf/bin:${PATH}"
 # ENV PATH="/home/buildharness/.asdf/shims:/home/buildharness/.asdf/bin:${PATH}"
 
 # Install golang. Get versions using 'asdf list all golang'
-ARG GOLANG_VERSION="1.18.3"
+ARG GOLANG_VERSION="1.19"
 ENV GOLANG_VERSION=${GOLANG_VERSION}
 RUN asdf plugin add golang \
   && asdf install golang "${GOLANG_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN asdf plugin add terraform \
   && asdf install terraform "${TERRAFORM_VERSION}"
 
 # Install tflint. Get versions using 'asdf list all tflint'
-ARG TFLINT_VERSION="0.38.1"
+ARG TFLINT_VERSION="0.39.2"
 ENV TFLINT_VERSION=${TFLINT_VERSION}
 RUN asdf plugin add tflint \
   && asdf install tflint "${TFLINT_VERSION}"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BIGBANG_VERSION := 1.37.0
 ZARF_VERSION := v0.19.5
 
 # The version of the build harness container to use
-BUILD_HARNESS_VERSION := 0.0.12
+BUILD_HARNESS_VERSION := 0.0.13
 
 # Figure out which Zarf binary we should use based on the operating system we are on
 ZARF_BIN := zarf

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/defenseunicorns/zarf-package-software-factory
 go 1.19
 
 require (
-	github.com/gruntwork-io/terratest v0.40.17
+	github.com/gruntwork-io/terratest v0.40.19
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/defenseunicorns/zarf-package-software-factory
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gruntwork-io/terratest v0.40.17

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3i
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gruntwork-io/go-commons v0.8.0 h1:k/yypwrPqSeYHevLlEDmvmgQzcyTwrlZGRaxEM6G0ro=
 github.com/gruntwork-io/go-commons v0.8.0/go.mod h1:gtp0yTtIBExIZp7vyIV9I0XQkVwiQZze678hvDXof78=
-github.com/gruntwork-io/terratest v0.40.17 h1:veSr7MUtk5GRDg5/pZ9qLUvrylr7yuRw0fY9UaSHbuI=
-github.com/gruntwork-io/terratest v0.40.17/go.mod h1:enUpxNMsQfiJTTJMGqiznxohqJ4cYPU+nzI3bQNw1WM=
+github.com/gruntwork-io/terratest v0.40.19 h1:slnTF0Amrc9yRVUV/X/fHlVWKNF0H8fwa2OLyeV2IOA=
+github.com/gruntwork-io/terratest v0.40.19/go.mod h1:JGeIGgLbxbG9/Oqm06z6YXVr76CfomdmLkV564qov+8=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
@@ -337,10 +337,6 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.4 h1:wZRexSlwd7ZXfKINDLsO4r7WBt3gTKONc6K/VesHvHM=
-github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
-github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=


### PR DESCRIPTION
- Update renovate pre-commit-hooks
- Update golang to 1.19
- Update python to 3.10.6
- Upgrade tflint to 0.39.2
- Upgrade tfsec to 1.27.1
- Upgrade golangci-lint to 1.48.0
- Update check-jsonschema pre-commit hook to 0.17.1
- Update terratest lib to 0.40.19
- Upgrade Terraform to 1.2.7