### PR TITLE
Add GCC to apt install of test runners

### DIFF
--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -61,7 +61,7 @@ func SetupTestPlatform(t *testing.T, platform *types.TestPlatform) {
 		require.NoError(t, err)
 
 		// Install dependencies. Doing it here since the instance user-data is being flaky, still saying things like make are not installed
-		output, err := platform.RunSSHCommandAsSudo("apt update && apt upgrade -y && apt dist-upgrade -y && apt install -y jq git make wget && sysctl -w vm.max_map_count=262144")
+		output, err := platform.RunSSHCommandAsSudo("apt update && apt upgrade -y && apt dist-upgrade -y && apt install -y jq git make wget gcc && sysctl -w vm.max_map_count=262144")
 		require.NoError(t, err, output)
 
 		// Install LinuxBrew for stupid, stupid reasons


### PR DESCRIPTION
Linxubrew added gcc as a dependency. Linuxbrew was throwing errors since it wasn't installed.