### PR TITLE
Update the test environment's OS version to Ubuntu 22.04 and update to latest Zarf version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BIGBANG_VERSION := 1.39.0
 
 # The version of Zarf to use. To keep this repo as portable as possible the Zarf binary will be downloaded and added to
 # the build folder.
-ZARF_VERSION := v0.19.5
+ZARF_VERSION := v0.21.3
 
 # The version of the build harness container to use
 BUILD_HARNESS_VERSION := 0.0.13

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
     config.vm.boot_timeout = 600
 
     config.vm.disk :disk, size: "100GB", primary: true
-    config.vm.box = "boxomatic/ubuntu-20.04"
+    config.vm.box = "boxomatic/ubuntu-22.04"
 
     config.vm.hostname = "zarf-examples"
     config.vm.synced_folder '.', '/vagrant', disabled: true

--- a/test/e2e/e2e_basic_smoke_test.go
+++ b/test/e2e/e2e_basic_smoke_test.go
@@ -98,19 +98,19 @@ func TestAllServicesRunning(t *testing.T) {
 
 		// Ensure that the services do not accept discontinued TLS versions. If they reject TLSv1.1 it is assumed that they also reject anything below TLSv1.1.
 		// Ensure that GitLab does not accept TLSv1.1
-		output, err = platform.RunSSHCommand(`/home/linuxbrew/.linuxbrew/bin/sslscan gitlab.bigbang.dev | grep "TLSv1.1" | grep "disabled"`)
+		output, err = platform.RunSSHCommand(`sslscan gitlab.bigbang.dev | grep "TLSv1.1" | grep "disabled"`)
 		require.NoError(t, err, output)
 		// Ensure that Jenkins does not accept TLSv1.1
-		output, err = platform.RunSSHCommand(`/home/linuxbrew/.linuxbrew/bin/sslscan jenkins.bigbang.dev | grep "TLSv1.1" | grep "disabled"`)
+		output, err = platform.RunSSHCommand(`sslscan jenkins.bigbang.dev | grep "TLSv1.1" | grep "disabled"`)
 		require.NoError(t, err, output)
 		// Ensure that Jira does not accept TLSv1.1
-		output, err = platform.RunSSHCommand(`/home/linuxbrew/.linuxbrew/bin/sslscan jira.bigbang.dev | grep "TLSv1.1" | grep "disabled"`)
+		output, err = platform.RunSSHCommand(`sslscan jira.bigbang.dev | grep "TLSv1.1" | grep "disabled"`)
 		require.NoError(t, err, output)
 		// Ensure that Confluence does not accept TLSv1.1
-		output, err = platform.RunSSHCommand(`/home/linuxbrew/.linuxbrew/bin/sslscan confluence.bigbang.dev | grep "TLSv1.1" | grep "disabled"`)
+		output, err = platform.RunSSHCommand(`sslscan confluence.bigbang.dev | grep "TLSv1.1" | grep "disabled"`)
 		require.NoError(t, err, output)
 		// Ensure that Artifactory does not accept TLSv1.1
-		output, err = platform.RunSSHCommand(`/home/linuxbrew/.linuxbrew/bin/sslscan artifactory.bigbang.dev | grep "TLSv1.1" | grep "disabled"`)
+		output, err = platform.RunSSHCommand(`sslscan artifactory.bigbang.dev | grep "TLSv1.1" | grep "disabled"`)
 		require.NoError(t, err, output)
 	})
 }

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -61,17 +61,7 @@ func SetupTestPlatform(t *testing.T, platform *types.TestPlatform) {
 		require.NoError(t, err)
 
 		// Install dependencies. Doing it here since the instance user-data is being flaky, still saying things like make are not installed
-		output, err := platform.RunSSHCommandAsSudo("apt update && apt upgrade -y && apt dist-upgrade -y && apt install -y jq git make wget gcc && sysctl -w vm.max_map_count=262144")
-		require.NoError(t, err, output)
-
-		// Install LinuxBrew for stupid, stupid reasons
-		output, err = platform.RunSSHCommand(`curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh | bash`)
-		require.NoError(t, err, output)
-		output, err = platform.RunSSHCommand(`echo 'eval \"$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"' >> ~/.bash_profile && eval \"$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\"`)
-		require.NoError(t, err, output)
-
-		// Install sshscan using stupid LinuxBrew, cause it's stupid. Go ahead, try to run `apt install sshscan`, I dare you. I double dare you. :cry:
-		output, err = platform.RunSSHCommand(`/home/linuxbrew/.linuxbrew/bin/brew install sslscan`)
+		output, err := platform.RunSSHCommandAsSudo("apt update && apt upgrade -y && apt dist-upgrade -y && apt install -y jq git make wget sslscan && sysctl -w vm.max_map_count=262144")
 		require.NoError(t, err, output)
 
 		// Clone the repo idempotently

--- a/test/tf/public-ec2-instance/main.tf
+++ b/test/tf/public-ec2-instance/main.tf
@@ -30,6 +30,12 @@ resource "aws_instance" "public" {
     volume_size = 200
   }
 
+  user_data = <<_EOF_
+#!/bin/bash
+echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
+service ssh reload
+_EOF_
+
   # This EC2 Instance has a public IP and will be accessible directly from the public Internet
   associate_public_ip_address = true
 
@@ -104,6 +110,6 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
   }
 }


### PR DESCRIPTION
This PR updates the test environment's Ubuntu version from 20.04 LTS to 22.04.

This change also removes the need for sslscan's installation workaround using Homebrew.

Fixes #323 