### PR TITLE
Replace EFK stack with PLG

### DIFF
--- a/kustomizations/bigbang/common/values.yaml
+++ b/kustomizations/bigbang/common/values.yaml
@@ -227,68 +227,36 @@ gatekeeper:
             - "local-path-storage"
 
 logging:
-  enabled: true
-  git:
-    repo: http://zarf-gitea-http.zarf.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__elasticsearch-kibana.git
-  values:
-    istio:
-      mtls:
-        mode: PERMISSIVE
-    kibana:
-      count: 1
-      resources:
-        requests:
-          memory: "1Gi"
-          cpu: "100m"
-        limits:
-          memory: "1Gi"
-          cpu: "500m"
-    elasticsearch:
-      master:
-        count: 1
-        # Uncomment this if you want to specify a specific storageclass
-#        persistence:
-#          storageClassName: "your-storage-class-name-here"
-        resources:
-          limits:
-            cpu: "500m"
-            memory: "3Gi"
-          requests:
-            cpu: "100m"
-            memory: "3Gi"
-      data:
-        count: 1
-        # Uncomment this if you want to specify a specific storageclass
-#        persistence:
-#          storageClassName: "your-storage-class-name-here"
-        resources:
-          limits:
-            cpu: "500m"
-            memory: "3Gi"
-          requests:
-            cpu: "100m"
-            memory: "3Gi"
+  enabled: false
 
 eckoperator:
+  enabled: false
+
+fluentbit:
+  enabled: false
+
+loki:
   enabled: true
   git:
-    repo: http://zarf-gitea-http.zarf.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__eck-operator.git
+    repo: http://zarf-gitea-http.zarf.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__sandbox__loki.git
+  strategy: "monolith"
+  objectStorage:
+    endpoint: minio.minio.svc.cluster.local
+    region: "us-east-1"
+    # accessKey: "" -- Added in environment-bb/values.yaml
+    # accessSecret: "" -- Added in environment-bb/values.yaml
+    bucketNames: "loki-logs"
   values:
+    minio:
+      enabled: false
     istio:
       mtls:
         mode: PERMISSIVE
-    resources:
-      limits:
-        cpu: "200m"
-        memory: "256Mi"
-      requests:
-        cpu: "100m"
-        memory: "256Mi"
 
-fluentbit:
+promtail:
   enabled: true
   git:
-    repo: http://zarf-gitea-http.zarf.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__core__fluentbit.git
+    repo: http://zarf-gitea-http.zarf.svc.cluster.local:3000/zarf-git-user/mirror__repo1.dso.mil__platform-one__big-bang__apps__sandbox__promtail.git
   values:
     istio:
       mtls:
@@ -509,6 +477,10 @@ addons:
             objectLock: true
           # gitlab-pages
           - name: "gitlab-pages"
+            region: "us-east-1"
+            objectLock: true
+          # loki-logs
+          - name: "loki-logs"
             region: "us-east-1"
             objectLock: true
         pools:

--- a/kustomizations/bigbang/environment-bb/values.yaml
+++ b/kustomizations/bigbang/environment-bb/values.yaml
@@ -142,3 +142,7 @@ addons:
     objectStorage:
       accessKey: "changeme"         # needs to match the value in kustomizations/bigbang/environment-bb-minio-user-credentials/values.yaml
       accessSecret: "changeme"      # needs to match the value in kustomizations/bigbang/environment-bb-minio-user-credentials/values.yaml
+  loki:
+    objectStorage:
+      accessKey: "changeme"         # needs to match the value in kustomizations/bigbang/environment-bb-minio-user-credentials/values.yaml
+      accessSecret: "changeme"      # needs to match the value in kustomizations/bigbang/environment-bb-minio-user-credentials/values.yaml

--- a/manifests/big-bang.yaml
+++ b/manifests/big-bang.yaml
@@ -42,15 +42,11 @@ spec:
     - apiVersion: helm.toolkit.fluxcd.io/v2beta1
       kind: HelmRelease
       namespace: bigbang
-      name: ek
+      name: loki
     - apiVersion: helm.toolkit.fluxcd.io/v2beta1
       kind: HelmRelease
       namespace: bigbang
-      name: eck-operator
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
-      kind: HelmRelease
-      namespace: bigbang
-      name: fluent-bit
+      name: promtail
     - apiVersion: helm.toolkit.fluxcd.io/v2beta1
       kind: HelmRelease
       namespace: bigbang

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -60,6 +60,8 @@ components:
       - https://repo1.dso.mil/platform-one/big-bang/apps/core/elasticsearch-kibana.git
       - https://repo1.dso.mil/platform-one/big-bang/apps/core/eck-operator.git
       - https://repo1.dso.mil/platform-one/big-bang/apps/core/fluentbit.git
+      - https://repo1.dso.mil/platform-one/big-bang/apps/sandbox/loki.git
+      - https://repo1.dso.mil/platform-one/big-bang/apps/sandbox/promtail.git
       - https://repo1.dso.mil/platform-one/big-bang/apps/core/monitoring.git
       # Disabling Twistlock for now since Big Bang now needs a license to be specified for Twistlock to initialize successfully. Will re-evaluate turning it back on later, or possibly swap it out for Neuvector once that becomes available.
       # - https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/twistlock.git
@@ -98,6 +100,8 @@ components:
       - "registry1.dso.mil/ironbank/elastic/kibana/kibana:8.2.3"
       - "registry1.dso.mil/ironbank/elastic/eck-operator/eck-operator:2.3.0"
       - "registry1.dso.mil/ironbank/opensource/fluent/fluent-bit:1.9.6"
+      - "registry1.dso.mil/ironbank/opensource/grafana/loki:2.5.0"
+      - "registry1.dso.mil/ironbank/opensource/grafana/promtail:v2.5.0"
       - "registry1.dso.mil/ironbank/big-bang/grafana/grafana-plugins:9.0.1"
       - "registry1.dso.mil/ironbank/kiwigrid/k8s-sidecar:1.19.2"
       - "registry1.dso.mil/ironbank/opensource/kubernetes/kube-state-metrics:v2.5.0"


### PR DESCRIPTION
Currently the Elasticsearch, Fluent-bit, Kibana are the default logging stack in the software factory. This PR replaces it with Promtail, Loki and Grafana.