### PR TITLE
 Enable RWX mounts by deploying Longhorn.io

### DIFF
--- a/day2/zarf.yaml
+++ b/day2/zarf.yaml
@@ -12,6 +12,12 @@ components:
       - name: setup-config
         files:
           - ../manifests/setup.yaml
+  - name: longhorn
+    required: true
+    manifests:
+      - name: longhorn
+        files:
+          - ../manifests/longhorn.yaml
   - name: postgres-operator
     required: true
     manifests:

--- a/kustomizations/bigbang/common/values-bigbang.yaml
+++ b/kustomizations/bigbang/common/values-bigbang.yaml
@@ -220,6 +220,7 @@ gatekeeper:
           excludedNamespaces:
             - "kube-sytem"
             - "local-path-storage"
+            - "longhorn-system"
       noPrivilegedContainers:
         match:
           excludedNamespaces:

--- a/kustomizations/bigbang/common/values-bigbang.yaml
+++ b/kustomizations/bigbang/common/values-bigbang.yaml
@@ -187,6 +187,7 @@ gatekeeper:
             - "kube-sytem"
             - "istio-system"
             - "local-path-storage"
+            - "longhorn"
         parameters:
           repos:
             - "${ZARF_REGISTRY}"
@@ -200,6 +201,7 @@ gatekeeper:
           excludedNamespaces:
             - "kube-sytem"
             - "local-path-storage"
+            - "longhorn"
       hostNetworking:
         match:
           excludedNamespaces:
@@ -211,12 +213,18 @@ gatekeeper:
           excludedNamespaces:
             - "kube-sytem"
             - "local-path-storage"
+            - "longhorn"
       volumeTypes:
         match:
           # Make Kind/K3d happy
           excludedNamespaces:
             - "kube-sytem"
             - "local-path-storage"
+            - "longhorn"
+      noPrivilegedContainers:
+        match:
+          excludedNamespaces:
+            - "longhorn"
 
 logging:
   enabled: false
@@ -244,8 +252,12 @@ loki:
   values:
     read:
       replicas: 1
+      persistence:
+        storageClass: "longhorn"
     write:
       replicas: 1
+      persistence:
+        storageClass: "longhorn"
     minio:
       enabled: false
     istio:
@@ -642,9 +654,8 @@ addons:
             limits:
               cpu: 400m
               memory: 600Mi
-          # Uncomment this if you want to specify a particular storage class
-#          persistence:
-#            storageClass: "your-storage-class-name-here"
+          persistence:
+            storageClass: "longhorn"
         gitlab-shell:
           init:
             resources:

--- a/kustomizations/bigbang/common/values-bigbang.yaml
+++ b/kustomizations/bigbang/common/values-bigbang.yaml
@@ -201,7 +201,7 @@ gatekeeper:
           excludedNamespaces:
             - "kube-sytem"
             - "local-path-storage"
-            - "longhorn"
+            - "longhorn-system"
       hostNetworking:
         match:
           excludedNamespaces:
@@ -213,18 +213,17 @@ gatekeeper:
           excludedNamespaces:
             - "kube-sytem"
             - "local-path-storage"
-            - "longhorn"
+            - "longhorn-system"
       volumeTypes:
         match:
           # Make Kind/K3d happy
           excludedNamespaces:
             - "kube-sytem"
             - "local-path-storage"
-            - "longhorn"
       noPrivilegedContainers:
         match:
           excludedNamespaces:
-            - "longhorn"
+            - "longhorn-system"
 
 logging:
   enabled: false

--- a/kustomizations/bigbang/databases.yaml
+++ b/kustomizations/bigbang/databases.yaml
@@ -51,8 +51,7 @@ spec:
           numberOfInstances: 3
           volume:
             size: "2Gi"
-            # Uncomment this if you want to specify a particular storage class
-            # storageClass: "your-storage-class-name-here"
+            storageClass: "longhorn"
           # enableLogicalBackup: true
           # logicalBackupSchedule: "*/2 * * * *"
           resources:

--- a/kustomizations/gitlab-redis/redis-config/values.yaml
+++ b/kustomizations/gitlab-redis/redis-config/values.yaml
@@ -1,3 +1,5 @@
+global:
+  storageClass: "longhorn"
 auth:
   enabled: false
 sentinel:

--- a/kustomizations/longhorn/base/gitrepository.yaml
+++ b/kustomizations/longhorn/base/gitrepository.yaml
@@ -1,0 +1,12 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: GitRepository
+metadata:
+  name: longhorn
+  namespace: softwarefactoryaddons
+spec:
+  interval: 5m
+  url: http://zarf-gitea-http.zarf.svc.cluster.local:3000/zarf-git-user/mirror__github.com__longhorn__longhorn.git
+  ref:
+    tag: v1.3.2
+  secretRef:
+    name: private-git-server

--- a/kustomizations/longhorn/base/helmrelease.yaml
+++ b/kustomizations/longhorn/base/helmrelease.yaml
@@ -4,7 +4,7 @@ metadata:
   name: longhorn
   namespace: softwarefactoryaddons
 spec:
-  targetNamespace: longhorn
+  targetNamespace: longhorn-system
   releaseName: longhorn
   interval: 5m
   timeout: 10m

--- a/kustomizations/longhorn/base/helmrelease.yaml
+++ b/kustomizations/longhorn/base/helmrelease.yaml
@@ -1,0 +1,34 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: longhorn
+  namespace: softwarefactoryaddons
+spec:
+  targetNamespace: longhorn
+  releaseName: longhorn
+  interval: 5m
+  timeout: 10m
+  chart:
+    spec:
+      interval: 1m
+      chart: chart
+      sourceRef:
+        kind: GitRepository
+        name: longhorn
+  test:
+    enable: false
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: 5
+      remediateLastFailure: true
+    cleanupOnFail: true
+  rollback:
+    timeout: 30m
+    cleanupOnFail: false
+  valuesFrom:
+    - kind: ConfigMap
+      name: longhorn-common
+      valuesKey: values.yaml

--- a/kustomizations/longhorn/base/kustomization.yaml
+++ b/kustomizations/longhorn/base/kustomization.yaml
@@ -1,0 +1,16 @@
+configurations:
+  - transformer.yaml
+
+commonLabels:
+  owner: softwarefactoryaddons
+
+resources:
+  - gitrepository.yaml
+  - helmrelease.yaml
+
+configMapGenerator:
+  - name: longhorn-common
+    namespace: softwarefactoryaddons
+    behavior: create
+    literals:
+      - values.yaml=

--- a/kustomizations/longhorn/base/transformer.yaml
+++ b/kustomizations/longhorn/base/transformer.yaml
@@ -1,0 +1,6 @@
+---
+nameReference:
+- kind: ConfigMap
+  fieldSpecs:
+  - path: spec/valuesFrom/name
+    kind: HelmRelease

--- a/kustomizations/longhorn/kustomization.yaml
+++ b/kustomizations/longhorn/kustomization.yaml
@@ -1,0 +1,12 @@
+resources:
+  - base
+
+configMapGenerator:
+  - name: longhorn-common
+    namespace: softwarefactoryaddons
+    behavior: replace
+    files:
+      - values.yaml=longhorn-config/values.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kustomizations/longhorn/longhorn-config/values.yaml
+++ b/kustomizations/longhorn/longhorn-config/values.yaml
@@ -1,0 +1,6 @@
+csi:
+  kubeletRootDir: /var/lib/kubelet
+persistence:
+  defaultClassReplicaCount: 1
+defaultSettings:
+  replicaSoftAntiAffinity: true

--- a/kustomizations/longhorn/networkpolicy.yaml
+++ b/kustomizations/longhorn/networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-istiod
+  namespace: longhorn-system
+spec:
+  egress:
+    - ports:
+        - port: 15012
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              app.kubernetes.io/name: istio-controlplane
+          podSelector:
+            matchLabels:
+              app: istiod
+  podSelector: {}
+  policyTypes:
+    - Egress

--- a/kustomizations/softwarefactoryaddons/artifactory/common-values.yaml
+++ b/kustomizations/softwarefactoryaddons/artifactory/common-values.yaml
@@ -20,10 +20,9 @@ artifactory:
   enabled: true
   nginx:
     enabled: false
-  # Uncomment if you want to specify a particular storage class
-#  artifactory:
-#    persistence:
-#      storageClassName: "your-storage-class-here"
+  artifactory:
+    persistence:
+      storageClassName: "longhorn"
 postgresql:
   enabled: false
 artifactory-ha:

--- a/kustomizations/softwarefactoryaddons/base/postgresql.yaml
+++ b/kustomizations/softwarefactoryaddons/base/postgresql.yaml
@@ -11,8 +11,7 @@ spec:
   numberOfInstances: 3
   volume:
     size: "2Gi"
-    # Uncomment this if you want to specify a particular storage class
-#    storageClass: "your-storage-class-name-here"
+    storageClass: "longhorn"
   users:
     # role for confluence application
     confluence: []
@@ -40,8 +39,7 @@ spec:
   numberOfInstances: 3
   volume:
     size: "2Gi"
-    # Uncomment this if you want to specify a particular storage class
-#    storageClass: "your-storage-class-name-here"
+    storageClass: "longhorn"
   users:
     jira: []
   databases:
@@ -68,8 +66,7 @@ spec:
   numberOfInstances: 3
   volume:
     size: "2Gi"
-    # Uncomment this if you want to specify a particular storage class
-#    storageClass: "your-storage-class-name-here"
+    storageClass: "longhorn"
   # enableLogicalBackup: true
   # logicalBackupSchedule: "*/2 * * * *"
   resources:

--- a/kustomizations/softwarefactoryaddons/confluence/common-values.yaml
+++ b/kustomizations/softwarefactoryaddons/confluence/common-values.yaml
@@ -49,16 +49,16 @@ volumes:
   localHome:
     persistentVolumeClaim:
       create: true
-      # storageClassName: your-storage-class-here
+      storageClassName: longhorn
       resources:
         requests:
           storage: 1Gi
 
   # # sharedHome requires an RWX storageclass
-  # sharedHome:
-  #   persistentVolumeClaim:
-  #     create: true
-  #     storageClassName: your-storage-class-here
-  #     resources:
-  #       requests:
-  #         storage: 1Gi
+  sharedHome:
+    persistentVolumeClaim:
+      create: true
+      storageClassName: longhorn
+      resources:
+        requests:
+          storage: 1Gi

--- a/kustomizations/softwarefactoryaddons/jenkins/common-values.yaml
+++ b/kustomizations/softwarefactoryaddons/jenkins/common-values.yaml
@@ -8,14 +8,14 @@ controller:
       memory: "256Mi"
     limits:
       cpu: "2000m"
-      memory: "4096Mi"
+      memory: "8192Mi"
   initContainerResources:
     requests:
       cpu: "50m"
       memory: "256Mi"
     limits:
       cpu: "2000m"
-      memory: "4096Mi"
+      memory: "8192Mi"
   installPlugins:
     # Top level plugins
     - kubernetes:3651.v908e7db_10d06
@@ -116,4 +116,4 @@ agent:
   alwaysPullImage: true
 persistence:
   enabled: true
-#  storageClass: "your-storage-class-here"
+  storageClass: "longhorn"

--- a/kustomizations/softwarefactoryaddons/jira/values.yaml
+++ b/kustomizations/softwarefactoryaddons/jira/values.yaml
@@ -47,16 +47,16 @@ volumes:
   localHome:
     persistentVolumeClaim:
       create: true
-      # storageClassName: your-storage-class-here
+      storageClassName: longhorn
       resources:
         requests:
           storage: 1Gi
 
   # sharedHome requires an RWX storageclass
-  # sharedHome:
-  #   persistentVolumeClaim:
-  #     create: true
-  #     storageClassName: your-storage-class-here
-  #     resources:
-  #       requests:
-  #         storage: 1Gi
+  sharedHome:
+    persistentVolumeClaim:
+      create: true
+      storageClassName: longhorn
+      resources:
+        requests:
+          storage: 1Gi

--- a/manifests/big-bang.yaml
+++ b/manifests/big-bang.yaml
@@ -39,10 +39,6 @@ spec:
     - apiVersion: helm.toolkit.fluxcd.io/v2beta1
       kind: HelmRelease
       namespace: bigbang
-      name: gatekeeper
-    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
-      kind: HelmRelease
-      namespace: bigbang
       name: loki
     - apiVersion: helm.toolkit.fluxcd.io/v2beta1
       kind: HelmRelease

--- a/manifests/longhorn.yaml
+++ b/manifests/longhorn.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: longhorn
+  namespace: flux-system
+spec:
+  interval: 5m
+  path: "./kustomizations/longhorn"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: zarf-package-software-factory
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2beta1
+      kind: HelmRelease
+      namespace: softwarefactoryaddons
+      name: longhorn
+  timeout: 5m
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-gpg
+  postBuild:
+    substitute:
+      ZARF_REGISTRY: "###ZARF_REGISTRY###"
+      ZARF_REGISTRY_AUTH_PULL: "###ZARF_REGISTRY_AUTH_PULL###"

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -81,6 +81,13 @@ metadata:
   labels:
     istio-injection: enabled
 ---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: longhorn-system
+  labels:
+    istio-injection: enabled
+---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -16,7 +16,7 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: longhorn
+  name: longhorn-system
 ---
 apiVersion: v1
 kind: Namespace

--- a/manifests/setup.yaml
+++ b/manifests/setup.yaml
@@ -16,6 +16,11 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: longhorn
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: postgres-operator
   labels:
     istio-injection: enabled

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -62,7 +62,7 @@ func SetupTestPlatform(t *testing.T, platform *types.TestPlatform) {
 		require.NoError(t, err)
 
 		// Install dependencies. Doing it here since the instance user-data is being flaky, still saying things like make are not installed
-		output, err := platform.RunSSHCommandAsSudo("apt update && apt install -y jq git make wget sslscan && sysctl -w vm.max_map_count=262144")
+		output, err := platform.RunSSHCommandAsSudo("apt update && apt install -y jq git make wget sslscan nfs-common && sysctl -w vm.max_map_count=262144")
 		require.NoError(t, err, output)
 
 		// Clone the repo idempotently

--- a/test/tf/public-ec2-instance/main.tf
+++ b/test/tf/public-ec2-instance/main.tf
@@ -27,7 +27,7 @@ resource "aws_instance" "public" {
   key_name               = var.key_pair_name
 
   root_block_device {
-    volume_size = 400
+    volume_size = 500
   }
 
   user_data = <<_EOF_
@@ -36,6 +36,8 @@ echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
 service ssh reload
 sysctl fs.inotify.max_user_instances=512
 sysctl -p
+modprobe iscsi_tcp
+echo "iscsi_tcp" >> /etc/modules
 _EOF_
 
   # This EC2 Instance has a public IP and will be accessible directly from the public Internet

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -27,6 +27,27 @@ components:
     repos:
       - https://github.com/defenseunicorns/zarf-package-software-factory.git
 
+  - name: longhorn
+    required: true
+    manifests:
+      - name: longhorn
+        files:
+          - manifests/longhorn.yaml
+    repos:
+      - https://github.com/longhorn/longhorn.git@v1.3.2
+    images:
+      - longhornio/longhorn-engine:v1.3.2
+      - longhornio/longhorn-manager:v1.3.2
+      - longhornio/longhorn-ui:v1.3.2
+      - longhornio/longhorn-instance-manager:v1_20221003
+      - longhornio/longhorn-share-manager:v1_20221003
+      - longhornio/backing-image-manager:v3_20221003
+      - longhornio/csi-attacher:v3.4.0
+      - longhornio/csi-provisioner:v2.1.2
+      - longhornio/csi-node-driver-registrar:v2.5.0
+      - longhornio/csi-resizer:v1.2.0
+      - longhornio/csi-snapshotter:v3.0.3
+
   - name: postgres-operator
     required: true
     manifests:


### PR DESCRIPTION
This PR enables another default storageclass via Longhorn which has the ability to provide RWX mounts. Note that this PR doesn't enable Istio within the longhorn namespace, which needs to be added at a latter time.

Closes #401
Closes #299 