### PR TITLE
Fix creation of zarf-config.toml in test

### DIFF
--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -74,7 +74,7 @@ func SetupTestPlatform(t *testing.T, platform *types.TestPlatform) {
 		require.NoError(t, err, output)
 
 		// Add config file to ~/app/build
-		output, err = platform.RunSSHCommandAsSudo(`echo 'no_progress = true' > ~/app/build/zarf-config.toml`)
+		output, err = platform.RunSSHCommandAsSudo(`echo '"'"'no_progress = true'"'"' > ~/app/build/zarf-config.toml`)
 		require.NoError(t, err, output)
 
 		// Log into registry1.dso.mil


### PR DESCRIPTION
Single quotes inside single quotes need to be "escaped"