### PR TITLE
Add env var for Availability Zone For Testing

### DIFF
--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -35,7 +35,6 @@ func SetupTestPlatform(t *testing.T, platform *types.TestPlatform) { //nolint:fu
 	require.NoError(t, err)
 	registry1Password, err := getEnvVar("REGISTRY1_PASSWORD")
 	require.NoError(t, err)
-	subnetAvailabilityZone := fmt.Sprintf("%s%s", awsRegion, "b")
 	namespace := "di2me"
 	stage := "terratest"
 	name := fmt.Sprintf("e2e-%s", random.UniqueId())
@@ -46,13 +45,12 @@ func SetupTestPlatform(t *testing.T, platform *types.TestPlatform) { //nolint:fu
 		terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 			TerraformDir: platform.TestFolder,
 			Vars: map[string]interface{}{
-				"aws_region":               awsRegion,
-				"subnet_availability_zone": subnetAvailabilityZone,
-				"namespace":                namespace,
-				"stage":                    stage,
-				"name":                     name,
-				"key_pair_name":            keyPairName,
-				"instance_type":            instanceType,
+				"aws_region":    awsRegion,
+				"namespace":     namespace,
+				"stage":         stage,
+				"name":          name,
+				"key_pair_name": keyPairName,
+				"instance_type": instanceType,
 			},
 		})
 		teststructure.SaveTerraformOptions(t, platform.TestFolder, terraformOptions)

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -35,6 +35,7 @@ func SetupTestPlatform(t *testing.T, platform *types.TestPlatform) { //nolint:fu
 	require.NoError(t, err)
 	registry1Password, err := getEnvVar("REGISTRY1_PASSWORD")
 	require.NoError(t, err)
+	awsAvailabilityZone := getAwsAvailabilityZone(awsRegion)
 	namespace := "di2me"
 	stage := "terratest"
 	name := fmt.Sprintf("e2e-%s", random.UniqueId())
@@ -45,12 +46,13 @@ func SetupTestPlatform(t *testing.T, platform *types.TestPlatform) { //nolint:fu
 		terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 			TerraformDir: platform.TestFolder,
 			Vars: map[string]interface{}{
-				"aws_region":    awsRegion,
-				"namespace":     namespace,
-				"stage":         stage,
-				"name":          name,
-				"key_pair_name": keyPairName,
-				"instance_type": instanceType,
+				"aws_region":            awsRegion,
+				"aws_availability_zone": awsAvailabilityZone,
+				"namespace":             namespace,
+				"stage":                 stage,
+				"name":                  name,
+				"key_pair_name":         keyPairName,
+				"instance_type":         instanceType,
 			},
 		})
 		teststructure.SaveTerraformOptions(t, platform.TestFolder, terraformOptions)
@@ -170,6 +172,17 @@ func getAwsRegion() (string, error) {
 	}
 
 	return val, nil
+}
+
+// getAwsAvailabilityZone returns the desired AWS Availability Zone to use by first checking the env var AWS_AVAILABILITY_ZONE,
+// We default to {awsRegion}b if env var is not specified.
+func getAwsAvailabilityZone(awsRegion string) string {
+	val, present := os.LookupEnv("AWS_AVAILABILITY_ZONE")
+	if !present {
+		val = fmt.Sprintf("%s%s", awsRegion, "b")
+	}
+
+	return val
 }
 
 // getEnvVar gets an environment variable, returning an error if it isn't found.

--- a/test/tf/public-ec2-instance/main.tf
+++ b/test/tf/public-ec2-instance/main.tf
@@ -12,8 +12,15 @@ provider "aws" {
   region = var.aws_region
 }
 
+# Get available availability zones
 data "aws_availability_zones" "available" {
   state = "available"
+}
+
+# Get a random available availability zone
+resource "random_shuffle" "az" {
+  input = data.aws_availability_zones.available.names
+  result_count = 1
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -35,7 +42,7 @@ resource "aws_internet_gateway" "terratest_igw" {
 resource "aws_subnet" "terratest_public_subnet" {
   vpc_id                  = aws_vpc.terratest_vpc.id
   cidr_block              = "10.0.1.0/24"
-  availability_zone       = data.aws_availability_zones.available.names[0]
+  availability_zone       = random_shuffle.az.result[0]
   map_public_ip_on_launch = true
 
   tags = {

--- a/test/tf/public-ec2-instance/main.tf
+++ b/test/tf/public-ec2-instance/main.tf
@@ -12,17 +12,6 @@ provider "aws" {
   region = var.aws_region
 }
 
-# Get available availability zones
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
-# Get a random available availability zone
-resource "random_shuffle" "az" {
-  input = data.aws_availability_zones.available.names
-  result_count = 1
-}
-
 # ---------------------------------------------------------------------------------------------------------------------
 # CREATE VPC
 # ---------------------------------------------------------------------------------------------------------------------
@@ -42,7 +31,7 @@ resource "aws_internet_gateway" "terratest_igw" {
 resource "aws_subnet" "terratest_public_subnet" {
   vpc_id                  = aws_vpc.terratest_vpc.id
   cidr_block              = "10.0.1.0/24"
-  availability_zone       = random_shuffle.az.result[0]
+  availability_zone       = var.aws_availability_zone
   map_public_ip_on_launch = true
 
   tags = {

--- a/test/tf/public-ec2-instance/main.tf
+++ b/test/tf/public-ec2-instance/main.tf
@@ -12,6 +12,10 @@ provider "aws" {
   region = var.aws_region
 }
 
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # CREATE VPC
 # ---------------------------------------------------------------------------------------------------------------------
@@ -31,7 +35,7 @@ resource "aws_internet_gateway" "terratest_igw" {
 resource "aws_subnet" "terratest_public_subnet" {
   vpc_id                  = aws_vpc.terratest_vpc.id
   cidr_block              = "10.0.1.0/24"
-  availability_zone       = var.subnet_availability_zone
+  availability_zone       = data.aws_availability_zones.available.names[0]
   map_public_ip_on_launch = true
 
   tags = {

--- a/test/tf/public-ec2-instance/variables.tf
+++ b/test/tf/public-ec2-instance/variables.tf
@@ -17,11 +17,6 @@ variable "aws_region" {
   type        = string
 }
 
-variable "subnet_availability_zone" {
-  description = "The AWS availability zone to deploy the subnet to"
-  type        = string
-}
-
 variable "namespace" {
   type        = string
   description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"

--- a/test/tf/public-ec2-instance/variables.tf
+++ b/test/tf/public-ec2-instance/variables.tf
@@ -17,6 +17,11 @@ variable "aws_region" {
   type        = string
 }
 
+variable "aws_availability_zone" {
+  description = "The AWS availability zone to use"
+  type        = string
+}
+
 variable "namespace" {
   type        = string
   description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"


### PR DESCRIPTION
I updated the terratest code to default to {AWS_REGION}b for availability zone. I made it so that you can also set the AWS_AVAILABILITY_ZONE if needing to overirde for test.

I spent some time, trial and error trying to solve the issue of an availability zone being at capacity during test in terraform. I couldn't figure out a good enough solution. 

I entertained the idea of trying to handle that issue in terratest, but digging into how terratest works I didn't see a clear path. Allowing it to fail and then teardown would keep things clean. And if we need to change availability zones for test to pass I added the environment variable to do so.

If we want a more robust solution to handle issues when standing up IaC automatically for test we can create another issue to dig into that?