### PR TITLE
Day 2 package name update

### DIFF
--- a/day2/zarf.yaml
+++ b/day2/zarf.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/zarf/v0.25.0/zarf.schema.json
 kind: ZarfPackageConfig
 metadata:
-  name: day-two-update
+  name: software-factory
 
 components:
   - name: setup


### PR DESCRIPTION
The Day 2 zarf package name needs to match the original zarf package that we are updating